### PR TITLE
Use `student_identifier` only to get files

### DIFF
--- a/R/assist_grading-wrappers.R
+++ b/R/assist_grading-wrappers.R
@@ -46,7 +46,9 @@ assist_grading <- function(
     example_assignment_path,
     example_feedback_path,
     example_student_identifier,
-    missing_assignment_grade = NA
+    missing_assignment_grade = NA,
+    assignment_folder = NA,
+    number_assignment = 1 # default is that there is 1 assignment (that makes sense...)
 ) {
   
   core_assist_grading(
@@ -61,7 +63,9 @@ assist_grading <- function(
     questions_to_grade = "all",
     students_to_grade = "all",
     team_grading = FALSE,
-    github_issues = FALSE
+    github_issues = FALSE,
+    assignment_folder = assignment_folder,
+    number_assignment = number_assignment
   )
   
 }
@@ -71,17 +75,19 @@ assist_grading <- function(
 #' @title Team assisted grading
 #' @export
 assist_team_grading <- function(
-  rubric_path,
-  roster_path,
-  grading_progress_log_path,
-  final_grade_sheet_path,
-  example_assignment_path,
-  example_feedback_path,
-  example_team_identifier,
-  missing_assignment_grade = NA,
-  questions_to_grade = "all",
-  teams_to_grade = "all",
-  github_issues = FALSE
+    rubric_path,
+    roster_path,
+    grading_progress_log_path,
+    final_grade_sheet_path,
+    example_assignment_path,
+    example_feedback_path,
+    example_team_identifier,
+    missing_assignment_grade = NA,
+    questions_to_grade = "all",
+    teams_to_grade = "all",
+    github_issues = FALSE,
+    assignment_folder = NA,
+    number_assignment = 1 # default is that there is 1 assignment (that makes sense...)
 ) {
   
   core_assist_grading(
@@ -96,7 +102,9 @@ assist_team_grading <- function(
     questions_to_grade = questions_to_grade,
     students_to_grade = teams_to_grade,
     team_grading = TRUE,
-    github_issues = github_issues
+    github_issues = github_issues,
+    assignment_folder = assignment_folder,
+    number_assignment = number_assignment
   )
 }
 
@@ -105,17 +113,19 @@ assist_team_grading <- function(
 #' @title Advanced assisted grading
 #' @export
 assist_advanced_grading <- function(
-  rubric_path,
-  roster_path,
-  grading_progress_log_path,
-  final_grade_sheet_path,
-  example_assignment_path,
-  example_feedback_path,
-  example_student_identifier,
-  missing_assignment_grade = NA,
-  questions_to_grade = "all",
-  students_to_grade = "all",
-  github_issues = FALSE
+    rubric_path,
+    roster_path,
+    grading_progress_log_path,
+    final_grade_sheet_path,
+    example_assignment_path,
+    example_feedback_path,
+    example_student_identifier,
+    missing_assignment_grade = NA,
+    questions_to_grade = "all",
+    students_to_grade = "all",
+    github_issues = FALSE,
+    assignment_folder = NA,
+    number_assignment = 1 # default is that there is 1 assignment (that makes sense...)
 ) {
   
   core_assist_grading(
@@ -130,7 +140,9 @@ assist_advanced_grading <- function(
     questions_to_grade = questions_to_grade,
     students_to_grade = students_to_grade,
     team_grading = FALSE,
-    github_issues = github_issues
+    github_issues = github_issues,
+    assignment_folder = assignment_folder,
+    number_assignment = number_assignment
   )
   
 }

--- a/R/core_assist_grading.R
+++ b/R/core_assist_grading.R
@@ -25,7 +25,9 @@ core_assist_grading <- function(
     questions_to_grade = "all",
     students_to_grade = "all",
     team_grading = FALSE,
-    github_issues = FALSE
+    github_issues = FALSE,
+    assignment_folder,
+    number_assignment
   ) {
   
   # Check example_assignment_path is valid
@@ -150,7 +152,9 @@ core_assist_grading <- function(
     example_student_identifier = example_student_identifier, 
     roster_path = roster_path,
     github_issues = github_issues,
-    team_grading = team_grading
+    team_grading = team_grading,
+    assignment_folder = assignment_folder,
+    number_assignment = number_assignment
   )
   
   # Specify which students to grade


### PR DESCRIPTION
I used this package this past summer semester and made some changes/updates. When you download assignments from Canvas, it gives every file a unique number (aside from the student identifier) and also keeps the name that the students gave the file. So all files have different names. Same with when people submit assignments late via email.
So I added the option to search for assignment files by `student_identifier` only. You do still need to give the full file name of the first student (I'd like to change this too though). 
I implemented the change by defining an `assignment_folder =` argument, which is the name of the folder where the assignment files are stored. This assumes that this folder only contains assignments. I can still work on error proofing this.
I also added an argument for the number of assignment parts, to make sure this feature doesn't break. 
The main code changes are in `core_assist_grading`, with an if-else statement.
I am really new to making packages so I haven't updated any of the comments at the top of the scripts, but can do that if you prefer. I haven't tested this new code with the team grading option, or pushing things to GitHub...